### PR TITLE
Escaping attributes

### DIFF
--- a/lib/placeholdit.rb
+++ b/lib/placeholdit.rb
@@ -8,11 +8,11 @@ module Placeholdit
       src = "http://placehold.it/#{size}"
 
       config = {
-        :alt => (opts[:text] || "A placeholder image"),
+        :alt => CGI::escape(opts[:text] || "A placeholder image"),
         :class => "placeholder",
         :height => (size.split('x')[1] || size.split('x')[0]),
         :width => size.split('x')[0],
-        :title => opts[:title]
+        :title => (CGI::escape(opts[:title]) if opts[:title])
       }.merge!(opts)
 
       # Placehold.it preferences
@@ -23,7 +23,7 @@ module Placeholdit
         src += "/#{remove_hex_pound(config[:text_color])}"
       end
       if config[:text]
-        src += "&text=#{config[:text]}"
+        src += "&amp;text=#{CGI::escape(config[:text])}"
       end
 
       image_tag = "<img src='#{src}' alt='#{config[:alt]}' class='#{config[:class]}' height='#{config[:height]}' width='#{config[:width]}'"

--- a/spec/placeholdit_spec.rb
+++ b/spec/placeholdit_spec.rb
@@ -8,42 +8,42 @@ describe Placeholdit::ViewHelpers do
   let(:view) { MyView.new }
 
   it "should accept integers as params" do
-    view.placeholdit_image_tag(500).should == "<img src='http://placehold.it/500' alt='A placeholder image' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag(500).should == "<img src='http://placehold.it/500' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
   end
 
   it "should accept a string" do
-    view.placeholdit_image_tag("500").should == "<img src='http://placehold.it/500' alt='A placeholder image' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag("500").should == "<img src='http://placehold.it/500' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
   end
 
   it "should accept a componded WxH" do
-    view.placeholdit_image_tag("500x500").should == "<img src='http://placehold.it/500x500' alt='A placeholder image' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag("500x500").should == "<img src='http://placehold.it/500x500' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
   end
 
   it "should accept custom text" do
-    view.placeholdit_image_tag("500x500", text: 'Buy me!').should == "<img src='http://placehold.it/500x500&text=Buy me!' alt='Buy me!' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag("500x500", text: 'Buy me!').should == "<img src='http://placehold.it/500x500&amp;text=Buy+me%21' alt='Buy+me%21' class='placeholder' height='500' width='500' />"
   end
 
   it "should accept custom colors" do
-    view.placeholdit_image_tag("500", text_color: 'fff', background_color: '000').should == "<img src='http://placehold.it/500/000/fff' alt='A placeholder image' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag("500", text_color: 'fff', background_color: '000').should == "<img src='http://placehold.it/500/000/fff' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
   end
 
   it "should strip the pound from hex colors" do
-    view.placeholdit_image_tag("500", text_color: '#fff', background_color: '000').should == "<img src='http://placehold.it/500/000/fff' alt='A placeholder image' class='placeholder' height='500' width='500' />"
-    view.placeholdit_image_tag("500", text_color: '#fff', background_color: '#000000').should == "<img src='http://placehold.it/500/000000/fff' alt='A placeholder image' class='placeholder' height='500' width='500' />"
-    view.placeholdit_image_tag("500", text_color: 'fff', background_color: '#000000').should == "<img src='http://placehold.it/500/000000/fff' alt='A placeholder image' class='placeholder' height='500' width='500' />"
-    view.placeholdit_image_tag("500", text_color: 'ffffff', background_color: '#000000').should == "<img src='http://placehold.it/500/000000/ffffff' alt='A placeholder image' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag("500", text_color: '#fff', background_color: '000').should == "<img src='http://placehold.it/500/000/fff' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag("500", text_color: '#fff', background_color: '#000000').should == "<img src='http://placehold.it/500/000000/fff' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag("500", text_color: 'fff', background_color: '#000000').should == "<img src='http://placehold.it/500/000000/fff' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
+    view.placeholdit_image_tag("500", text_color: 'ffffff', background_color: '#000000').should == "<img src='http://placehold.it/500/000000/ffffff' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
   end
 
   it "should accept title" do
-    view.placeholdit_image_tag("500", title: "Lorem ipsum").should == "<img src='http://placehold.it/500' alt='A placeholder image' class='placeholder' height='500' width='500' title='Lorem ipsum' />"
+    view.placeholdit_image_tag("500", title: "Lorem ipsum").should == "<img src='http://placehold.it/500' alt='A+placeholder+image' class='placeholder' height='500' width='500' title='Lorem ipsum' />"
   end
 
   it "should alias to placeholdit" do
-    view.placeholdit("500", text_color: 'fff', background_color: '000').should == "<img src='http://placehold.it/500/000/fff' alt='A placeholder image' class='placeholder' height='500' width='500' />"
+    view.placeholdit("500", text_color: 'fff', background_color: '000').should == "<img src='http://placehold.it/500/000/fff' alt='A+placeholder+image' class='placeholder' height='500' width='500' />"
   end
 
   it "should accept style" do
-    view.placeholdit_image_tag("500", style: "float:right;").should == "<img src='http://placehold.it/500' alt='A placeholder image' class='placeholder' height='500' width='500' style='float:right;' />"
+    view.placeholdit_image_tag("500", style: "float:right;").should == "<img src='http://placehold.it/500' alt='A+placeholder+image' class='placeholder' height='500' width='500' style='float:right;' />"
   end
 
 end


### PR DESCRIPTION
The generated URLs should have their attributes escaped - this way they pass HTML validation.